### PR TITLE
Avoid recursion

### DIFF
--- a/epel/lib.sh
+++ b/epel/lib.sh
@@ -122,7 +122,7 @@ epelEnableMainRepo() {
 
 
 epelDisableRepos() {
-  epelDisableRepos "$1" 0
+  epelEnableRepos "$1" 0
 }
 
 


### PR DESCRIPTION
After merging #2, the call to `epelDisableRepos` goes into infinite recursion, causing bash to crash in the end.

The #2 moved this functionality to enabeRepos but was not changed to use this function when disabling repo