### PR TITLE
drop epel-internal recommendation

### DIFF
--- a/epel/main.fmf
+++ b/epel/main.fmf
@@ -10,8 +10,6 @@ test: ./runtest.sh
 require:
 - rpm
 - curl
-recommend:
-- library(distribution/epel-internal)
 duration: 5m
 enabled: true
 tag: []


### PR DESCRIPTION
This approach causes some issues (#9). Let's drop it while it is actually not necessary at time point.

Can be reintroduced later as needed.